### PR TITLE
Add bin folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ src/test/data/sandbox/
 # MacOS custom attributes files created by Finder
 .DS_Store
 docs/_site/
+bin/


### PR DESCRIPTION
Minor change to `.gitignore` so that mac users (aka me) dont commit binary files to repo