### PR TITLE
Add Delete Meetings Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.meeting.Attendee;
 import seedu.address.model.meeting.Meeting;
 
 /**
- * Adds a person to the address book.
+ * Adds a meeting to the address book.
  */
 public class AddMeetingCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Adds a meeting to the address book.
+ */
+public class DeleteMeetingCommand extends Command {
+
+    public static final String COMMAND_WORD = "deletem";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD 
+            + ": Deletes the meeting identified by the index number used in the displayed meetings list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + "1";
+
+    public static final String MESSAGE_DELETE_MEETING_SUCCESS = "Meeting deleted: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteMeetingCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Meeting> lastShownList = model.getFilteredMeetingList();
+
+        if(targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+        }
+
+        Meeting meetingToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteMeeting(meetingToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_MEETING_SUCCESS, Messages.format(meetingToDelete)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteMeetingCommand)) {
+            return false;
+        }
+
+        DeleteMeetingCommand otherDeleteMeetingCommand = (DeleteMeetingCommand) other;
+        return targetIndex.equals(otherDeleteMeetingCommand.targetIndex);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.AddMeetingCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteMeetingCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -85,6 +86,10 @@ public class AddressBookParser {
 
         case AddMeetingCommand.COMMAND_WORD:
             return new AddMeetingCommandParser().parse(arguments);
+        
+        case DeleteMeetingCommand.COMMAND_WORD:
+            return new DeleteMeetingCommandParser().parse(arguments);
+
         case RemoveMeetingContactCommand.COMMAND_WORD:
             return new RemoveMeetingContactCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteMeetingCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteMeetingCommand object
+ */
+public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteMeetingCommand
+     * and returns a DeleteMeetingCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteMeetingCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteMeetingCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/meeting/TitleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/meeting/TitleContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.meeting;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Meetings}'s {@code Title} matches any of the keywords given.
+ */
+public class TitleContainsKeywordsPredicate implements Predicate<Meeting> {
+    private final List<String> keywords;
+
+    public TitleContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Meeting meeting) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(meeting.getTitle().toString(), keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TitleContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        TitleContainsKeywordsPredicate otherTitleContainsKeywordsPredicate = (TitleContainsKeywordsPredicate) other;
+        return keywords.equals(otherTitleContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -21,6 +21,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.TitleContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -124,12 +126,15 @@ public class CommandTestUtil {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
+        List<Person> expectedFilteredPersonList = new ArrayList<>(actualModel.getFilteredPersonList());
+        List<Meeting> expectedFilteredMeetingList = new ArrayList<>(actualModel.getFilteredMeetingList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
-        assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
+        assertEquals(expectedFilteredPersonList, actualModel.getFilteredPersonList());
+        assertEquals(expectedFilteredMeetingList, actualModel.getFilteredMeetingList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
@@ -142,6 +147,20 @@ public class CommandTestUtil {
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the meeting at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showMeetingAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredMeetingList().size());
+
+        Meeting meeting = model.getFilteredMeetingList().get(targetIndex.getZeroBased());
+        final String[] splitName = meeting.getTitle().toString().split("\\s+");
+        model.updateFilteredMeetingList(new TitleContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredMeetingList().size());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteMeetingCommandTest.java
@@ -1,0 +1,123 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showMeetingAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_MEETING;
+import static seedu.address.testutil.TypicalMeetings.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteMeetingCommand}.
+ */
+public class DeleteMeetingCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Meeting meetingToDelete = model.getFilteredMeetingList().get(INDEX_FIRST_MEETING.getZeroBased());
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(INDEX_FIRST_MEETING);
+
+        String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS,
+                Messages.format(meetingToDelete));
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteMeeting(meetingToDelete);
+
+        assertCommandSuccess(deleteMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredMeetingList().size() + 1);
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteMeetingCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showMeetingAtIndex(model, INDEX_FIRST_MEETING);
+
+        Meeting meetingToDelete = model.getFilteredMeetingList().get(INDEX_FIRST_MEETING.getZeroBased());
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(INDEX_FIRST_MEETING);
+
+        String expectedMessage = String.format(DeleteMeetingCommand.MESSAGE_DELETE_MEETING_SUCCESS,
+                Messages.format(meetingToDelete));
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteMeeting(meetingToDelete);
+        showNoMeeting(expectedModel);
+
+        assertCommandSuccess(deleteMeetingCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showMeetingAtIndex(model, INDEX_FIRST_MEETING);
+
+        Index outOfBoundIndex = INDEX_SECOND_MEETING;
+        System.out.println("hi");
+        System.out.println(outOfBoundIndex.getZeroBased());
+        System.out.println(model.getAddressBook().getMeetingList().size());
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getMeetingList().size());
+
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteMeetingCommand, model, Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteMeetingCommand deleteFirstCommand = new DeleteMeetingCommand(INDEX_FIRST_MEETING);
+        DeleteMeetingCommand deleteSecondCommand = new DeleteMeetingCommand(INDEX_SECOND_MEETING);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteMeetingCommand deleteFirstCommandCopy = new DeleteMeetingCommand(INDEX_FIRST_MEETING);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different meeting -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        DeleteMeetingCommand deleteMeetingCommand = new DeleteMeetingCommand(targetIndex);
+        String expected = DeleteMeetingCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, deleteMeetingCommand.toString());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoMeeting(Model model) {
+        model.updateFilteredMeetingList(p -> false);
+
+        assertTrue(model.getFilteredMeetingList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteMeetingCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the DeleteMeetingCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeleteMeetingCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class DeleteMeetingCommandParserTest {
+
+    private DeleteMeetingCommandParser parser = new DeleteMeetingCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new DeleteMeetingCommand(INDEX_FIRST_MEETING));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalMeetings.java
+++ b/src/test/java/seedu/address/testutil/TypicalMeetings.java
@@ -1,5 +1,10 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.AddressBook;
 import seedu.address.model.meeting.Meeting;
 
 /**
@@ -12,4 +17,29 @@ public class TypicalMeetings {
             .withStart("20.09.2023 1000").withEnd("20.09.2023 1200")
             .withAttendees(TypicalPersons.getTypicalAttendees())
             .build();
+
+    public static final Meeting MEETING2 = new MeetingBuilder().withTitle("CS2107 meeting")
+            .withLocation("in person")
+            .withStart("20.09.2023 1000").withEnd("20.09.2023 1200")
+            .withAttendees(TypicalPersons.getTypicalAttendees())
+            .build();
+    
+    public static final Meeting MEETING3 = new MeetingBuilder().withTitle("CS2101 meeting")
+            .withLocation("com 3")
+            .withStart("20.09.2023 1000").withEnd("20.09.2023 1200")
+            .withAttendees(TypicalPersons.getTypicalAttendees())
+            .build();
+
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Meeting meeting : getTypicalMeetings()) {
+            ab.addMeeting(meeting);
+        }
+
+        return ab;
+    }
+
+    public static List<Meeting> getTypicalMeetings() {
+        return new ArrayList<>(Arrays.asList(MEETING1, MEETING2, MEETING3));
+    }
 }


### PR DESCRIPTION
Meetings are deleted by index
All relevant tests copied from delete person command Only functional when meetings view UI is added

Possible Extensions:
Add ability to delete meetings without index when viewing a meeting