### PR TITLE
ParseException refactor

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,15 @@ public class StringUtil {
             return false;
         }
     }
+
+    public static boolean isNumeric(String s) {
+        requireNonNull(s);
+
+        try {
+            Integer.parseInt(s);
+            return true;
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -66,6 +66,10 @@ public class StringUtil {
         }
     }
 
+    /**
+     * Returns true if {@code s} is an integer and false otherwise.
+     * @throws NullPointerException if {@code s} is null.
+     */
     public static boolean isNumeric(String s) {
         requireNonNull(s);
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,17 +13,28 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";
-    public static final String MESSAGE_INVALID_ATTENDEE_INDEX = "The attendee index provided is invalid";
+    // success messages
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_PERSON_VIEWED_OVERVIEW = "Listing details for %s!";
     public static final String MESSAGE_MEETING_VIEWED_OVERVIEW = "Listing details for meeting: %s";
+    public static final String MESSAGE_MEETINGS_LISTED_OVERVIEW = "%1$d meetings listed!";
+
+    // command parsing error messages
+    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format!";
     public static final String MESSAGE_DUPLICATE_FIELDS = "Multiple values specified for the following "
             + "single-valued field(s): ";
-    public static final String MESSAGE_MEETINGS_LISTED_OVERVIEW = "%1$d meetings listed!";
+    public static final String MESSAGE_INVALID_FIELDS = "Invalid parameters provided.";
+
+    // index parsing error messages
+    public static final String MESSAGE_INVALID_INDEX_FORMAT = "Index must be a positive integer.";
+    public static final String MESSAGE_MISSING_INDEX = "Index is a required parameter.";
+    public static final String MESSAGE_TOO_MANY_INDEXES = "Too many index arguments provided.";
+
+    // index value error messages
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid!";
+    public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid!";
+    public static final String MESSAGE_INVALID_ATTENDEE_INDEX = "The attendee index provided is invalid!";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/AddMeetingContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingContactCommand.java
@@ -21,6 +21,7 @@ import seedu.address.model.person.Person;
 public class AddMeetingContactCommand extends Command {
 
     public static final String COMMAND_WORD = "addmc";
+    public static final int EXPECTED_INDEXES = 2;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the contact indicated by the contact index to the attendees list of the meeting "

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Person;
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "deletec";
+    public static final int EXPECTED_INDEXES = 1;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.meeting.Meeting;
 public class DeleteMeetingCommand extends Command {
 
     public static final String COMMAND_WORD = "deletem";
+    public static final int EXPECTED_INDEXES = 1;
 
     public static final String MESSAGE_DELETE_MEETING_SUCCESS = "Meeting deleted: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -38,6 +38,7 @@ import seedu.address.model.tag.Tag;
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "editc";
+    public static final int EXPECTED_INDEXES = 1;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "

--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -35,6 +35,7 @@ import seedu.address.model.tag.Tag;
  */
 public class EditMeetingCommand extends Command {
     public static final String COMMAND_WORD = "editm";
+    public static final int EXPECTED_INDEXES = 1;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the meeting identified "
             + "by the index number used in the displayed meeting list. "

--- a/src/main/java/seedu/address/logic/commands/MarkMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkMeetingCommand.java
@@ -22,6 +22,7 @@ import seedu.address.model.person.Person;
 public class MarkMeetingCommand extends Command {
 
     public static final String COMMAND_WORD = "mark";
+    public static final int EXPECTED_INDEXES = 1;
 
     public static final String MESSAGE_MARK_MEETING_SUCCESS = "Meeting marked as complete: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/RemoveMeetingContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveMeetingContactCommand.java
@@ -20,6 +20,7 @@ import seedu.address.model.meeting.Meeting;
 public class RemoveMeetingContactCommand extends Command {
 
     public static final String COMMAND_WORD = "rmmc";
+    public static final int EXPECTED_INDEXES = 2;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Removes the attendee indicated by the attendee index in the attendees list of the meeting "

--- a/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.person.Person;
 public class ViewContactCommand extends Command {
 
     public static final String COMMAND_WORD = "viewc";
+    public static final int EXPECTED_INDEXES = 1;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views detailed information of the person identified "
             + "by the index number used in the displayed person list.\n"

--- a/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewMeetingCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.meeting.Meeting;
 public class ViewMeetingCommand extends Command {
 
     public static final String COMMAND_WORD = "viewm";
+    public static final int EXPECTED_INDEXES = 1;
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views detailed information of the meeting identified "
             + "by the index number used in the displayed meeting list.\n"

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -35,9 +35,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         try {
-            ArgumentMultimap argMultimap =
-                    ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LASTTIME,
-                            PREFIX_STATUS, PREFIX_REMARK, PREFIX_TAG);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                    PREFIX_LASTTIME, PREFIX_STATUS, PREFIX_REMARK, PREFIX_TAG);
 
             if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
                     || !argMultimap.getPreamble().isEmpty()) {
@@ -49,7 +48,8 @@ public class AddCommandParser implements Parser<AddCommand> {
             Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
             Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
             Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-            LocalDateTime lastContactedTime = ParserUtil.parseContactTime(argMultimap.getValue(PREFIX_LASTTIME).orElse(""));
+            LocalDateTime lastContactedTime = ParserUtil
+                    .parseContactTime(argMultimap.getValue(PREFIX_LASTTIME).orElse(""));
             Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).orElse(""));
             Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).orElse(""));
             Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
@@ -63,8 +63,8 @@ public class AddCommandParser implements Parser<AddCommand> {
     }
 
     /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -34,28 +34,32 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LASTTIME,
-                        PREFIX_STATUS, PREFIX_REMARK, PREFIX_TAG);
+        try {
+            ArgumentMultimap argMultimap =
+                    ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LASTTIME,
+                            PREFIX_STATUS, PREFIX_REMARK, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL)
+                    || !argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+            }
+
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LASTTIME,
+                    PREFIX_STATUS, PREFIX_REMARK);
+            Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+            Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+            Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+            LocalDateTime lastContactedTime = ParserUtil.parseContactTime(argMultimap.getValue(PREFIX_LASTTIME).orElse(""));
+            Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).orElse(""));
+            Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).orElse(""));
+            Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+            Person person = new Person(name, phone, email, lastContactedTime, status, remark, tagList);
+
+            return new AddCommand(person);
+        } catch (ParseException pe) {
+            throw new ParseException(AddCommand.MESSAGE_USAGE, pe);
         }
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LASTTIME,
-                PREFIX_STATUS, PREFIX_REMARK);
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        LocalDateTime lastContactedTime = ParserUtil.parseContactTime(argMultimap.getValue(PREFIX_LASTTIME).orElse(""));
-        Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).orElse(""));
-        Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).orElse(""));
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-
-        Person person = new Person(name, phone, email, lastContactedTime, status, remark, tagList);
-
-        return new AddCommand(person);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -40,8 +40,8 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
     public AddMeetingCommand parse(String args) throws ParseException {
         try {
             logger.info("Begin AddMeetingCommand Parse");
-            ArgumentMultimap argMultimap =
-                    ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END, PREFIX_TAG);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
+                    PREFIX_END, PREFIX_TAG);
 
             if (!arePrefixesPresent(argMultimap, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END)
                     || !argMultimap.getPreamble().isEmpty()) {
@@ -69,8 +69,8 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
     }
 
     /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
+     * Returns true if none of the prefixes contains empty {@code Optional} values
+     * in the given {@code ArgumentMultimap}.
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());

--- a/src/main/java/seedu/address/logic/parser/AddMeetingContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingContactCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -21,21 +19,17 @@ public class AddMeetingContactCommandParser implements Parser<AddMeetingContactC
      * @throws ParseException if the user input does not conform to the expected format
      */
     public AddMeetingContactCommand parse(String args) throws ParseException {
+        List<Index> indexes;
         try {
-            List<Index> indexes = ParserUtil.parseIndexes(args);
-            if (indexes.size() != 2) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingContactCommand.MESSAGE_USAGE));
-            }
-
-            Index meetingIndex = indexes.get(0);
-            Index contactIndex = indexes.get(1);
-            return new AddMeetingContactCommand(meetingIndex, contactIndex);
+            indexes = ParserUtil.parseIndexes(args, AddMeetingContactCommand.EXPECTED_INDEXES);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingContactCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(AddMeetingContactCommand.MESSAGE_USAGE, pe);
         }
-    }
 
+        Index meetingIndex = indexes.get(0);
+        Index contactIndex = indexes.get(1);
+
+        return new AddMeetingContactCommand(meetingIndex, contactIndex);
+    }
 }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.ParserUtil.verifyNoArgs;
 
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -73,21 +74,26 @@ public class AddressBookParser {
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
+            verifyNoArgs(arguments);
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
+            verifyNoArgs(arguments);
             return new ListCommand();
 
         case ListMeetingCommand.COMMAND_WORD:
+            verifyNoArgs(arguments);
             return new ListMeetingCommand();
 
         case ExitCommand.COMMAND_WORD:
+            verifyNoArgs(arguments);
             return new ExitCommand();
 
         case HelpCommand.COMMAND_WORD:
+            verifyNoArgs(arguments);
             return new HelpCommand();
 
         case ViewContactCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -50,7 +50,7 @@ public class AddressBookParser {
     public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT + "\n" + HelpCommand.MESSAGE_USAGE);
         }
 
         final String commandWord = matcher.group("commandWord");

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,13 +15,14 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        Index index;
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            index = ParserUtil.parseIndexes(args, DeleteCommand.EXPECTED_INDEXES).get(0);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(DeleteCommand.MESSAGE_USAGE, pe);
         }
+
+        return new DeleteCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,13 +15,14 @@ public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> 
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteMeetingCommand parse(String args) throws ParseException {
+        Index index;
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteMeetingCommand(index);
+            index = ParserUtil.parseIndexes(args, DeleteMeetingCommand.EXPECTED_INDEXES).get(0);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(DeleteMeetingCommand.MESSAGE_USAGE, pe);
         }
+
+        return new DeleteMeetingCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LASTTIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -32,49 +31,46 @@ public class EditCommandParser implements Parser<EditCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_LASTTIME,
-                        PREFIX_STATUS, PREFIX_REMARK, PREFIX_TAG);
-
-        Index index;
-
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            requireNonNull(args);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, 
+                    PREFIX_LASTTIME, PREFIX_STATUS, PREFIX_REMARK, PREFIX_TAG);
+
+            Index index = ParserUtil.parseIndexes(argMultimap.getPreamble(), EditCommand.EXPECTED_INDEXES).get(0);
+
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_STATUS);
+
+            EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+
+            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+                editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            }
+            if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+                editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
+            }
+            if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+                editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            }
+            if (argMultimap.getValue(PREFIX_LASTTIME).isPresent()) {
+                editPersonDescriptor.setLastContactedTime(ParserUtil.parseContactTime(
+                        argMultimap.getValue(PREFIX_LASTTIME).get()));
+            }
+            if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
+                editPersonDescriptor.setStatus(ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get()));
+            }
+            if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
+                editPersonDescriptor.setRemark(ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()));
+            }
+            parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+
+            if (!editPersonDescriptor.isAnyFieldEdited()) {
+                throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            }
+
+            return new EditCommand(index, editPersonDescriptor);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(EditCommand.MESSAGE_USAGE, pe);
         }
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_STATUS);
-
-        EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
-
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
-        if (argMultimap.getValue(PREFIX_LASTTIME).isPresent()) {
-            editPersonDescriptor.setLastContactedTime(ParserUtil.parseContactTime(
-                    argMultimap.getValue(PREFIX_LASTTIME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
-            editPersonDescriptor.setStatus(ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get()));
-        }
-        if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
-            editPersonDescriptor.setRemark(ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()));
-        }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
-
-        if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
-        }
-
-        return new EditCommand(index, editPersonDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -33,7 +33,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         try {
             requireNonNull(args);
-            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, 
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                     PREFIX_LASTTIME, PREFIX_STATUS, PREFIX_REMARK, PREFIX_TAG);
 
             Index index = ParserUtil.parseIndexes(argMultimap.getPreamble(), EditCommand.EXPECTED_INDEXES).get(0);

--- a/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
@@ -24,17 +24,18 @@ import seedu.address.model.tag.Tag;
 public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditMeetingCommand
-     * and returns an EditMeetingCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the
+     * EditMeetingCommand and returns an EditMeetingCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditMeetingCommand parse(String args) throws ParseException {
         try {
             requireNonNull(args);
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
-                            PREFIX_END, PREFIX_TAG);
+                    PREFIX_END, PREFIX_TAG);
 
-            Index index = ParserUtil.parseIndexes(argMultimap.getPreamble(), EditMeetingCommand.EXPECTED_INDEXES).get(0);
+            Index index = ParserUtil.parseIndexes(argMultimap.getPreamble(), EditMeetingCommand.EXPECTED_INDEXES)
+                    .get(0);
 
             argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END);
 
@@ -44,7 +45,8 @@ public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
                 editMeetingDescriptor.setTitle(ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
             }
             if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
-                editMeetingDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
+                editMeetingDescriptor
+                        .setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
             }
             if (argMultimap.getValue(PREFIX_START).isPresent()) {
                 editMeetingDescriptor.setStart(ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_START).get()));
@@ -66,9 +68,10 @@ public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
     }
 
     /**
-     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if {@code tags} is non-empty.
-     * If {@code tags} contain only one element which is an empty string, it will be parsed into a
-     * {@code Set<Tag>} containing zero tags.
+     * Parses {@code Collection<String> tags} into a {@code Set<Tag>} if
+     * {@code tags} is non-empty. If {@code tags} contain only one element which is
+     * an empty string, it will be parsed into a {@code Set<Tag>} containing zero
+     * tags.
      */
     private Optional<Set<Tag>> parseTagsForEdit(Collection<String> tags) throws ParseException {
         assert tags != null;

--- a/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
@@ -34,7 +34,7 @@ public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
                             PREFIX_END, PREFIX_TAG);
 
-            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            Index index = ParserUtil.parseIndexes(argMultimap.getPreamble(), EditMeetingCommand.EXPECTED_INDEXES).get(0);
 
             argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END);
 

--- a/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditMeetingCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
@@ -30,44 +29,40 @@ public class EditMeetingCommandParser implements Parser<EditMeetingCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditMeetingCommand parse(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
-                        PREFIX_END, PREFIX_TAG);
-
-        Index index;
-
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            requireNonNull(args);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
+                            PREFIX_END, PREFIX_TAG);
+
+            Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END);
+
+            EditMeetingDescriptor editMeetingDescriptor = new EditMeetingDescriptor();
+
+            if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
+                editMeetingDescriptor.setTitle(ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
+            }
+            if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
+                editMeetingDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
+            }
+            if (argMultimap.getValue(PREFIX_START).isPresent()) {
+                editMeetingDescriptor.setStart(ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_START).get()));
+            }
+            if (argMultimap.getValue(PREFIX_END).isPresent()) {
+                editMeetingDescriptor.setEnd(ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_END).get()));
+            }
+
+            parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editMeetingDescriptor::setTags);
+
+            if (!editMeetingDescriptor.isAnyFieldEdited()) {
+                throw new ParseException(EditMeetingCommand.MESSAGE_NOT_EDITED);
+            }
+
+            return new EditMeetingCommand(index, editMeetingDescriptor);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditMeetingCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(EditMeetingCommand.MESSAGE_USAGE, pe);
         }
-
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END);
-
-        EditMeetingDescriptor editMeetingDescriptor = new EditMeetingDescriptor();
-
-        if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
-            editMeetingDescriptor.setTitle(ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_LOCATION).isPresent()) {
-            editMeetingDescriptor.setLocation(ParserUtil.parseLocation(argMultimap.getValue(PREFIX_LOCATION).get()));
-        }
-        if (argMultimap.getValue(PREFIX_START).isPresent()) {
-            editMeetingDescriptor.setStart(ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_START).get()));
-        }
-        if (argMultimap.getValue(PREFIX_END).isPresent()) {
-            editMeetingDescriptor.setEnd(ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_END).get()));
-        }
-
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editMeetingDescriptor::setTags);
-
-        if (!editMeetingDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditMeetingCommand.MESSAGE_NOT_EDITED);
-        }
-
-        return new EditMeetingCommand(index, editMeetingDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LASTTIME;
@@ -30,43 +31,47 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        logger.info("Begin FindCommand parse");
-        assert args != null;
+        try {
+            logger.info("Begin FindCommand parse");
+            requireNonNull(args);
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_LASTTIME, PREFIX_STATUS, PREFIX_TAG);
-        if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_LASTTIME, PREFIX_STATUS, PREFIX_TAG);
-
-        logger.info("Begin creation of Meeting predicates");
-        String[] nameKeyWords = argMultimap.getValue(PREFIX_NAME).orElse("").split("\\s+");
-        String[] phoneValues = argMultimap.getValue(PREFIX_PHONE).orElse("").split("\\s+");
-        String[] emailKeyWords = argMultimap.getValue(PREFIX_EMAIL).orElse("").split("\\s+");
-        String[] statusKeyWords = argMultimap.getValue(PREFIX_STATUS).orElse("").split("\\s+");
-        String[] tagKeyWords = argMultimap.getValue(PREFIX_TAG).orElse("").split("\\s+");
-
-        LocalDateTime lastContacted = LocalDateTime.MIN;
-        if (argMultimap.getValue(PREFIX_LASTTIME).isPresent()) {
-            lastContacted = ParserUtil.parseContactTime(argMultimap.getValue(PREFIX_LASTTIME).get());
-            if (!LastContactedTime.isValidLastContactedTime(lastContacted)) {
-                throw new ParseException(LastContactedTime.MESSAGE_CONSTRAINTS);
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                    PREFIX_LASTTIME, PREFIX_STATUS, PREFIX_TAG);
+            if (!argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
             }
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                    PREFIX_LASTTIME, PREFIX_STATUS, PREFIX_TAG);
+
+            logger.info("Begin creation of Meeting predicates");
+            String[] nameKeyWords = argMultimap.getValue(PREFIX_NAME).orElse("").split("\\s+");
+            String[] phoneValues = argMultimap.getValue(PREFIX_PHONE).orElse("").split("\\s+");
+            String[] emailKeyWords = argMultimap.getValue(PREFIX_EMAIL).orElse("").split("\\s+");
+            String[] statusKeyWords = argMultimap.getValue(PREFIX_STATUS).orElse("").split("\\s+");
+            String[] tagKeyWords = argMultimap.getValue(PREFIX_TAG).orElse("").split("\\s+");
+
+            LocalDateTime lastContacted = LocalDateTime.MIN;
+            if (argMultimap.getValue(PREFIX_LASTTIME).isPresent()) {
+                lastContacted = ParserUtil.parseContactTime(argMultimap.getValue(PREFIX_LASTTIME).get());
+                if (!LastContactedTime.isValidLastContactedTime(lastContacted)) {
+                    throw new ParseException(LastContactedTime.MESSAGE_CONSTRAINTS);
+                }
+            }
+
+            GeneralPersonPredicate generalPersonPredicate = new GeneralPersonPredicate(
+                    nameKeyWords,
+                    phoneValues,
+                    emailKeyWords,
+                    lastContacted,
+                    statusKeyWords,
+                    tagKeyWords);
+
+            logger.info("All Person predicates created");
+
+            return new FindCommand(generalPersonPredicate);
+        } catch (ParseException pe) {
+            throw new ParseException(FindCommand.MESSAGE_USAGE, pe);
         }
-
-        GeneralPersonPredicate generalPersonPredicate = new GeneralPersonPredicate(
-                nameKeyWords,
-                phoneValues,
-                emailKeyWords,
-                lastContacted,
-                statusKeyWords,
-                tagKeyWords);
-
-        logger.info("All Person predicates created");
-
-        return new FindCommand(generalPersonPredicate);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindMeetingCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOCATION;
@@ -30,44 +31,48 @@ public class FindMeetingCommandParser implements Parser<FindMeetingCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindMeetingCommand parse(String args) throws ParseException {
-        logger.info("Begin FindMeetingCommand parse");
-        assert args != null;
+        try {
+            logger.info("Begin FindMeetingCommand parse");
+            requireNonNull(args); 
 
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
-                PREFIX_END, PREFIX_NAME, PREFIX_TAG);
-        if (!argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindMeetingCommand.MESSAGE_USAGE));
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
+                    PREFIX_END, PREFIX_NAME, PREFIX_TAG);
+            if (!argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+            }
+            argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
+                    PREFIX_END, PREFIX_NAME, PREFIX_TAG);
+
+            logger.info("Begin creation of Meeting predicates");
+            String[] titleKeyWords = argMultimap.getValue(PREFIX_TITLE).orElse("").split("\\s+");
+            String[] locationKeyWords = argMultimap.getValue(PREFIX_LOCATION).orElse("").split("\\s+");
+
+            LocalDateTime start = LocalDateTime.MIN;
+            LocalDateTime end = LocalDateTime.MAX;
+
+            if (argMultimap.getValue(PREFIX_START).isPresent() && argMultimap.getValue(PREFIX_END).isPresent()) {
+                start = ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_START).get());
+                end = ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_END).get());
+            }
+            if (!MeetingTime.isValidMeetingTime(start, end)) {
+                throw new ParseException(MeetingTime.MESSAGE_CONSTRAINTS);
+            }
+
+            String[] attendeeKeyWords = argMultimap.getValue(PREFIX_NAME).orElse("").split("\\s+");
+            String[] tagKeyWords = argMultimap.getValue(PREFIX_TAG).orElse("").split("\\s+");
+
+            GeneralMeetingPredicate generalMeetingPredicate = new GeneralMeetingPredicate(
+                    titleKeyWords,
+                    locationKeyWords,
+                    start, end,
+                    attendeeKeyWords,
+                    tagKeyWords);
+
+            logger.info("All Meeting predicates created");
+
+            return new FindMeetingCommand(generalMeetingPredicate);
+        } catch (ParseException pe) {
+            throw new ParseException(FindMeetingCommand.MESSAGE_USAGE, pe);
         }
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
-                PREFIX_END, PREFIX_NAME, PREFIX_TAG);
-
-        logger.info("Begin creation of Meeting predicates");
-        String[] titleKeyWords = argMultimap.getValue(PREFIX_TITLE).orElse("").split("\\s+");
-        String[] locationKeyWords = argMultimap.getValue(PREFIX_LOCATION).orElse("").split("\\s+");
-
-        LocalDateTime start = LocalDateTime.MIN;
-        LocalDateTime end = LocalDateTime.MAX;
-
-        if (argMultimap.getValue(PREFIX_START).isPresent() && argMultimap.getValue(PREFIX_END).isPresent()) {
-            start = ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_START).get());
-            end = ParserUtil.parseMeetingTime(argMultimap.getValue(PREFIX_END).get());
-        }
-        if (!MeetingTime.isValidMeetingTime(start, end)) {
-            throw new ParseException(MeetingTime.MESSAGE_CONSTRAINTS);
-        }
-
-        String[] attendeeKeyWords = argMultimap.getValue(PREFIX_NAME).orElse("").split("\\s+");
-        String[] tagKeyWords = argMultimap.getValue(PREFIX_TAG).orElse("").split("\\s+");
-
-        GeneralMeetingPredicate generalMeetingPredicate = new GeneralMeetingPredicate(
-                titleKeyWords,
-                locationKeyWords,
-                start, end,
-                attendeeKeyWords,
-                tagKeyWords);
-
-        logger.info("All Meeting predicates created");
-
-        return new FindMeetingCommand(generalMeetingPredicate);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindMeetingCommandParser.java
@@ -33,7 +33,7 @@ public class FindMeetingCommandParser implements Parser<FindMeetingCommand> {
     public FindMeetingCommand parse(String args) throws ParseException {
         try {
             logger.info("Begin FindMeetingCommand parse");
-            requireNonNull(args); 
+            requireNonNull(args);
 
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START,
                     PREFIX_END, PREFIX_NAME, PREFIX_TAG);

--- a/src/main/java/seedu/address/logic/parser/MarkMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkMeetingCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MarkMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,13 +15,14 @@ public class MarkMeetingCommandParser implements Parser<MarkMeetingCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public MarkMeetingCommand parse(String args) throws ParseException {
+        Index index;
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new MarkMeetingCommand(index);
+            index = ParserUtil.parseIndex(args);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkMeetingCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(MarkMeetingCommand.MESSAGE_USAGE, pe);
         }
+
+        return new MarkMeetingCommand(index);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/MarkMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkMeetingCommandParser.java
@@ -17,7 +17,7 @@ public class MarkMeetingCommandParser implements Parser<MarkMeetingCommand> {
     public MarkMeetingCommand parse(String args) throws ParseException {
         Index index;
         try {
-            index = ParserUtil.parseIndex(args);
+            index = ParserUtil.parseIndexes(args, MarkMeetingCommand.EXPECTED_INDEXES).get(0);
         } catch (ParseException pe) {
             throw new ParseException(MarkMeetingCommand.MESSAGE_USAGE, pe);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,6 +37,10 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
     public static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy HHmm");
 
+    /**
+     * Checks if the arguments are empty.
+     * @throws ParseException if arguments is not empty.
+     */
     public static void verifyNoArgs(String args) throws ParseException {
         if (!args.isEmpty()) {
             throw new ParseException(MESSAGE_INVALID_FIELDS);
@@ -76,14 +80,10 @@ public class ParserUtil {
         List<Index> indexes = new ArrayList<>();
 
         for (String indexString : indexStrings) {
-            // check if size overflows
-            if (indexes.size() >= expectedIndexes) {
-                // if it is another index, throw too many index exception
-                if (StringUtil.isNumeric(indexString)) {
+            if (indexes.size() >= expectedIndexes) { // check if size overflows
+                if (StringUtil.isNumeric(indexString)) { // if it is another index, throw too many index exception
                     throw new ParseException(MESSAGE_TOO_MANY_INDEXES);
-                }
-                // otherwise, throw invalid field exception
-                else {
+                } else { // otherwise, throw invalid field exception
                     throw new ParseException(MESSAGE_INVALID_FIELDS);
                 }
             }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,10 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_FIELDS;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_TOO_MANY_INDEXES;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -31,9 +35,6 @@ import seedu.address.model.tag.Tag;
  * classes.
  */
 public class ParserUtil {
-
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
-
     public static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy HHmm");
 
     /**
@@ -45,8 +46,11 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        if (trimmedIndex.equals("")) {
+            throw new ParseException(MESSAGE_MISSING_INDEX);
+        }
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(MESSAGE_INVALID_INDEX_FORMAT);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
@@ -56,16 +60,33 @@ public class ParserUtil {
      * ArrayList of {@code Indexes} and returns it. Leading and trailing whitespaces
      * will be trimmed.
      *
-     * @throws ParseException if any indexes are invalid (not non-zero
-     *                        unsigned integer).
+     * @throws ParseException if any indexes are invalid (not non-zero unsigned integer)
+     *                        or if there are too many indexes provided.
      */
-    public static List<Index> parseIndexes(String oneBasedIndexes) throws ParseException {
-        String[] indexStrings = oneBasedIndexes.trim().split("\\s+");
+    public static List<Index> parseIndexes(String oneBasedIndexes, int expectedIndexes) throws ParseException {
+        assert expectedIndexes > 0 : "Expected indexes must be positive";
 
-        // not elegant to use streams due to checked exception
+        String[] indexStrings = oneBasedIndexes.trim().split("\\s+");
         List<Index> indexes = new ArrayList<>();
+
         for (String indexString : indexStrings) {
+            // check if size overflows
+            if (indexes.size() >= expectedIndexes) {
+                // if it is another index, throw too many index exception
+                if (StringUtil.isNumeric(indexString)) {
+                    throw new ParseException(MESSAGE_TOO_MANY_INDEXES);
+                }
+                // otherwise, throw invalid field exception
+                else {
+                    throw new ParseException(MESSAGE_INVALID_FIELDS);
+                }
+            }
+
             indexes.add(parseIndex(indexString));
+        }
+
+        if (indexes.size() < expectedIndexes) {
+            throw new ParseException(MESSAGE_MISSING_INDEX);
         }
 
         return indexes;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -37,6 +37,12 @@ import seedu.address.model.tag.Tag;
 public class ParserUtil {
     public static final DateTimeFormatter FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy HHmm");
 
+    public static void verifyNoArgs(String args) throws ParseException {
+        if (!args.isEmpty()) {
+            throw new ParseException(MESSAGE_INVALID_FIELDS);
+        }
+    }
+
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading
      * and trailing whitespaces will be trimmed.

--- a/src/main/java/seedu/address/logic/parser/RemoveMeetingContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemoveMeetingContactCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import java.util.List;
 
 import seedu.address.commons.core.index.Index;
@@ -21,20 +19,16 @@ public class RemoveMeetingContactCommandParser implements Parser<RemoveMeetingCo
      * @throws ParseException if the user input does not conform the expected format
      */
     public RemoveMeetingContactCommand parse(String args) throws ParseException {
+        List<Index> indexes;
         try {
-            List<Index> indexes = ParserUtil.parseIndexes(args);
-            if (indexes.size() != 2) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveMeetingContactCommand.MESSAGE_USAGE));
-            }
-
-            Index meetingIndex = indexes.get(0);
-            Index attendeeIndex = indexes.get(1);
-            return new RemoveMeetingContactCommand(meetingIndex, attendeeIndex);
+            indexes = ParserUtil.parseIndexes(args, RemoveMeetingContactCommand.EXPECTED_INDEXES);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveMeetingContactCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(RemoveMeetingContactCommand.MESSAGE_USAGE, pe);
         }
-    }
 
+        Index meetingIndex = indexes.get(0);
+        Index attendeeIndex = indexes.get(1);
+
+        return new RemoveMeetingContactCommand(meetingIndex, attendeeIndex);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -17,7 +17,7 @@ public class ViewContactCommandParser implements Parser<ViewContactCommand> {
     public ViewContactCommand parse(String args) throws ParseException {
         Index index;
         try {
-            index = ParserUtil.parseIndex(args);
+            index = ParserUtil.parseIndexes(args, ViewContactCommand.EXPECTED_INDEXES).get(0);
         } catch (ParseException pe) {
             throw new ParseException(ViewContactCommand.MESSAGE_USAGE, pe);
         }

--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewContactCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,12 +15,13 @@ public class ViewContactCommandParser implements Parser<ViewContactCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ViewContactCommand parse(String args) throws ParseException {
+        Index index;
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new ViewContactCommand(index);
+            index = ParserUtil.parseIndex(args);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewContactCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(ViewContactCommand.MESSAGE_USAGE, pe);
         }
+
+        return new ViewContactCommand(index);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
@@ -17,7 +17,7 @@ public class ViewMeetingCommandParser implements Parser<ViewMeetingCommand> {
     public ViewMeetingCommand parse(String args) throws ParseException {
         Index index;
         try {
-            index = ParserUtil.parseIndex(args);
+            index = ParserUtil.parseIndexes(args, ViewMeetingCommand.EXPECTED_INDEXES).get(0);
         } catch (ParseException pe) {
             throw new ParseException(ViewMeetingCommand.MESSAGE_USAGE, pe);
         }

--- a/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewMeetingCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewMeetingCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,12 +15,13 @@ public class ViewMeetingCommandParser implements Parser<ViewMeetingCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ViewMeetingCommand parse(String args) throws ParseException {
+        Index index;
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new ViewMeetingCommand(index);
+            index = ParserUtil.parseIndex(args);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewMeetingCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(ViewMeetingCommand.MESSAGE_USAGE, pe);
         }
+
+        return new ViewMeetingCommand(index);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
+++ b/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
@@ -14,4 +14,14 @@ public class ParseException extends IllegalValueException {
     public ParseException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    @Override
+    public String getMessage() {
+        if(super.getCause() != null) {
+            return super.getCause().getMessage() + "\n" + super.getMessage();
+        }
+        else {
+            return super.getMessage();
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
+++ b/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
@@ -17,10 +17,9 @@ public class ParseException extends IllegalValueException {
 
     @Override
     public String getMessage() {
-        if(super.getCause() != null) {
+        if (super.getCause() != null) {
             return super.getCause().getMessage() + "\n" + super.getMessage();
-        }
-        else {
+        } else {
             return super.getMessage();
         }
     }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -61,8 +61,7 @@ public class AddCommandParserTest {
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB + STATUS_DESC_BOB
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB + STATUS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
     }
 
@@ -73,57 +72,57 @@ public class AddCommandParserTest {
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // multiple phones
         assertParseFailure(parser, PHONE_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // multiple emails
         assertParseFailure(parser, EMAIL_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // multiple fields repeated
         assertParseFailure(parser,
-                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY
-                        + validExpectedPersonString, Messages.getErrorMessageForDuplicatePrefixes(
-                                PREFIX_NAME, PREFIX_LASTTIME, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_STATUS));
+                validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY + validExpectedPersonString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_LASTTIME, PREFIX_EMAIL, PREFIX_PHONE,
+                        PREFIX_STATUS) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid value followed by valid value
 
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid email
         assertParseFailure(parser, INVALID_EMAIL_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid phone
         assertParseFailure(parser, INVALID_PHONE_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid status
         assertParseFailure(parser, INVALID_STATUS_DESC + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STATUS));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STATUS) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // valid value followed by invalid value
 
         // invalid name
         assertParseFailure(parser, validExpectedPersonString + INVALID_NAME_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid email
         assertParseFailure(parser, validExpectedPersonString + INVALID_EMAIL_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_EMAIL) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid phone
         assertParseFailure(parser, validExpectedPersonString + INVALID_PHONE_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid status
         assertParseFailure(parser, validExpectedPersonString + INVALID_STATUS_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STATUS));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STATUS) + "\n" + AddCommand.MESSAGE_USAGE);
 
     }
 
@@ -131,8 +130,9 @@ public class AddCommandParserTest {
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(BOB).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB + STATUS_DESC_BOB
-                + REMARK_DESC_BOB, new AddCommand(expectedPerson));
+        assertParseSuccess(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB + STATUS_DESC_BOB + REMARK_DESC_BOB,
+                new AddCommand(expectedPerson));
 
         // no status
         Person expectedPerson2 = new PersonBuilder(BOB).withStatus("").build();
@@ -142,58 +142,58 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        String expectedMessage = MESSAGE_INVALID_COMMAND_FORMAT + "\n" + AddCommand.MESSAGE_USAGE;
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB, expectedMessage);
 
         // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB, expectedMessage);
 
         // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB, expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB,
-                expectedMessage);
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + LASTTIME_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + LASTTIME_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid last contacted time
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_LASTTIME_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, LastContactedTime.MESSAGE_CONSTRAINTS);
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                LastContactedTime.MESSAGE_CONSTRAINTS + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS + "\n" + AddCommand.MESSAGE_USAGE);
 
         // invalid status
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB
-                + INVALID_STATUS_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Status.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB + INVALID_STATUS_DESC
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Status.MESSAGE_CONSTRAINTS + "\n" + AddCommand.MESSAGE_USAGE);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB,
-                Name.MESSAGE_CONSTRAINTS);
+                Name.MESSAGE_CONSTRAINTS + "\n" + AddCommand.MESSAGE_USAGE);
 
         // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + LASTTIME_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        assertParseFailure(parser,
+                PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + LASTTIME_DESC_BOB
+                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                MESSAGE_INVALID_COMMAND_FORMAT + "\n" + AddCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
@@ -44,9 +44,7 @@ public class AddMeetingCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1
-                + START_DESC_MEETING1 + END_DESC_MEETING1,
-                new AddMeetingCommand(expectedMeeting));
-
+                + START_DESC_MEETING1 + END_DESC_MEETING1, new AddMeetingCommand(expectedMeeting));
 
         // multiple tags - all accepted
         Meeting expectedMeetingMultipleTags = new MeetingBuilder(MEETING1).withAttendees().withTags(VALID_TAG_WORK)
@@ -56,12 +54,12 @@ public class AddMeetingCommandParserTest {
                 new AddMeetingCommand(expectedMeetingMultipleTags));
 
         /*
-        // multiple attendees - all accepted
-        Meeting expectedMeetingMultipleAttendees = new MeetingBuilder(MEETING1)
-                .withAttendees("Alice Pauline", "Bob Choo").build();
-        assertParseSuccess(parser, TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1
-                + START_DESC_MEETING1 + END_DESC_MEETING1 + ATTENDEE_DESC_ALICE + ATTENDEE_DESC_BOB,
-                new AddMeetingCommand(expectedMeetingMultipleAttendees));
+         * // multiple attendees - all accepted Meeting expectedMeetingMultipleAttendees
+         * = new MeetingBuilder(MEETING1) .withAttendees("Alice Pauline",
+         * "Bob Choo").build(); assertParseSuccess(parser, TITLE_DESC_MEETING1 +
+         * LOCATION_DESC_MEETING1 + START_DESC_MEETING1 + END_DESC_MEETING1 +
+         * ATTENDEE_DESC_ALICE + ATTENDEE_DESC_BOB, new
+         * AddMeetingCommand(expectedMeetingMultipleAttendees));
          */
     }
 
@@ -72,127 +70,132 @@ public class AddMeetingCommandParserTest {
 
         // multiple title
         assertParseFailure(parser, TITLE_DESC_MEETING1 + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // multiple locations
         assertParseFailure(parser, LOCATION_DESC_MEETING1 + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // multiple starts
         assertParseFailure(parser, START_DESC_MEETING1 + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_START));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_START) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // multiple endss
         assertParseFailure(parser, END_DESC_MEETING1 + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_END));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_END) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // multiple fields repeated
-        assertParseFailure(parser, validExpectedMeetingString + LOCATION_DESC_MEETING1 + START_DESC_MEETING1
-                + END_DESC_MEETING1 + TITLE_DESC_MEETING1 + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END));
+        assertParseFailure(parser,
+                validExpectedMeetingString + LOCATION_DESC_MEETING1 + START_DESC_MEETING1 + END_DESC_MEETING1
+                        + TITLE_DESC_MEETING1 + validExpectedMeetingString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE, PREFIX_LOCATION, PREFIX_START, PREFIX_END)
+                        + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid value followed by valid value
 
         // invalid title
         assertParseFailure(parser, INVALID_TITLE_DESC + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid location
         assertParseFailure(parser, INVALID_LOCATION_DESC + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid start
         assertParseFailure(parser, INVALID_START_DESC + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_START));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_START) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid end
         assertParseFailure(parser, INVALID_END_DESC + validExpectedMeetingString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_END));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_END) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // valid value followed by invalid value
 
         // invalid title
         assertParseFailure(parser, validExpectedMeetingString + INVALID_TITLE_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid location
         assertParseFailure(parser, validExpectedMeetingString + INVALID_LOCATION_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid start
         assertParseFailure(parser, validExpectedMeetingString + INVALID_START_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_START));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_START) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid end
         assertParseFailure(parser, validExpectedMeetingString + INVALID_END_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_END));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_END) + "\n" + AddMeetingCommand.MESSAGE_USAGE);
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero attendees
         Meeting expectedMeeting = new MeetingBuilder(MEETING1).withAttendees().withTags().build();
-        assertParseSuccess(parser, TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1
-                + START_DESC_MEETING1 + END_DESC_MEETING1, new AddMeetingCommand(expectedMeeting));
+        assertParseSuccess(parser,
+                TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1 + END_DESC_MEETING1,
+                new AddMeetingCommand(expectedMeeting));
     }
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE);
+        String expectedMessage = MESSAGE_INVALID_COMMAND_FORMAT + "\n" + AddMeetingCommand.MESSAGE_USAGE;
 
         // missing title prefix
-        assertParseFailure(parser, VALID_TITLE_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1
-                + END_DESC_MEETING1, expectedMessage);
+        assertParseFailure(parser,
+                VALID_TITLE_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1 + END_DESC_MEETING1,
+                expectedMessage);
 
         // missing location prefix
-        assertParseFailure(parser, TITLE_DESC_MEETING1 + VALID_LOCATION_MEETING1 + START_DESC_MEETING1
-                + END_DESC_MEETING1, expectedMessage);
+        assertParseFailure(parser,
+                TITLE_DESC_MEETING1 + VALID_LOCATION_MEETING1 + START_DESC_MEETING1 + END_DESC_MEETING1,
+                expectedMessage);
 
         // missing start prefix
-        assertParseFailure(parser, TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + VALID_START_MEETING1
-                + END_DESC_MEETING1, expectedMessage);
+        assertParseFailure(parser,
+                TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + VALID_START_MEETING1 + END_DESC_MEETING1,
+                expectedMessage);
 
         // missing end prefix
-        assertParseFailure(parser, TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1
-                + VALID_END_MEETING1, expectedMessage);
-
+        assertParseFailure(parser,
+                TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1 + VALID_END_MEETING1,
+                expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_TITLE_MEETING1 + VALID_LOCATION_MEETING1 + VALID_START_MEETING1
-                + VALID_END_MEETING1, expectedMessage);
+        assertParseFailure(parser,
+                VALID_TITLE_MEETING1 + VALID_LOCATION_MEETING1 + VALID_START_MEETING1 + VALID_END_MEETING1,
+                expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid title
-        assertParseFailure(parser, INVALID_TITLE_DESC + LOCATION_DESC_MEETING1 + START_DESC_MEETING1
-                + END_DESC_MEETING1, Title.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                INVALID_TITLE_DESC + LOCATION_DESC_MEETING1 + START_DESC_MEETING1 + END_DESC_MEETING1,
+                Title.MESSAGE_CONSTRAINTS + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid location
-        assertParseFailure(parser, TITLE_DESC_MEETING1 + INVALID_LOCATION_DESC + START_DESC_MEETING1
-                + END_DESC_MEETING1, Location.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                TITLE_DESC_MEETING1 + INVALID_LOCATION_DESC + START_DESC_MEETING1 + END_DESC_MEETING1,
+                Location.MESSAGE_CONSTRAINTS + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid start
-        assertParseFailure(parser, TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + INVALID_START_DESC
-                + END_DESC_MEETING1, MeetingTime.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + INVALID_START_DESC + END_DESC_MEETING1,
+                MeetingTime.MESSAGE_CONSTRAINTS + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid end
-        assertParseFailure(parser, TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1
-                + INVALID_END_DESC, MeetingTime.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1 + INVALID_END_DESC,
+                MeetingTime.MESSAGE_CONSTRAINTS + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
-
-        /*
-        // invalid attendee
-        assertParseFailure(parser, TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1 + START_DESC_MEETING1
-                + END_DESC_MEETING1 + INVALID_ATTENDEE_DESC, Attendee.MESSAGE_CONSTRAINTS);
-         */
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_TITLE_DESC + INVALID_LOCATION_DESC + START_DESC_MEETING1
-                + END_DESC_MEETING1, Title.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_TITLE_DESC + INVALID_LOCATION_DESC + START_DESC_MEETING1 + END_DESC_MEETING1,
+                Title.MESSAGE_CONSTRAINTS + "\n" + AddMeetingCommand.MESSAGE_USAGE);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_MEETING1 + LOCATION_DESC_MEETING1
-                + START_DESC_MEETING1 + END_DESC_MEETING1, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddMeetingCommand.MESSAGE_USAGE));
+                + START_DESC_MEETING1 + END_DESC_MEETING1,
+                MESSAGE_INVALID_COMMAND_FORMAT + "\n" + AddMeetingCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddMeetingContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMeetingContactCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_TOO_MANY_INDEXES;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
@@ -12,11 +14,11 @@ import seedu.address.logic.commands.AddMeetingContactCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path
- * variations outside the AddMeetingContactCommand code.
- * For example, inputs "1" and "1 abc" take the same path through the AddMeetingContactCommand,
- * and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * variations outside the AddMeetingContactCommand code. For example, inputs "1"
+ * and "1 abc" take the same path through the AddMeetingContactCommand, and
+ * therefore we test only one of them. The path variation for those two cases
+ * occur inside the ParserUtil, and therefore should be covered by the
+ * ParserUtilTest.
  */
 public class AddMeetingContactCommandParserTest {
 
@@ -29,14 +31,13 @@ public class AddMeetingContactCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a 1",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingContactCommand.MESSAGE_USAGE));
+        // invalid args
+        assertParseFailure(parser, "a 1", MESSAGE_INVALID_INDEX_FORMAT + "\n" + AddMeetingContactCommand.MESSAGE_USAGE);
 
-        assertParseFailure(parser, "1 1 2",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingContactCommand.MESSAGE_USAGE));
+        // too many args
+        assertParseFailure(parser, "1 1 2", MESSAGE_TOO_MANY_INDEXES + "\n" + AddMeetingContactCommand.MESSAGE_USAGE);
 
-        assertParseFailure(parser, "2",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingContactCommand.MESSAGE_USAGE));
+        // too few args
+        assertParseFailure(parser, "2", MESSAGE_MISSING_INDEX + "\n" + AddMeetingContactCommand.MESSAGE_USAGE);
     }
 }
-

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_FIELDS;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.ParserUtil.FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -76,7 +77,9 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
+                () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -109,7 +112,9 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
+                () -> parser.parseCommand(ExitCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -118,7 +123,7 @@ public class AddressBookParserTest {
         FindCommand command = (FindCommand) parser
                 .parseCommand(FindCommand.COMMAND_WORD + " n/Alice p/913 e/gmail lc/20.09.2023 1000 s/Active t/friend");
         assertEquals(new FindCommand(
-                preparePersonPredicate(new String[]{"Alice", "913", "gmail", "Active", "friend"}, lastContacted)),
+                preparePersonPredicate(new String[] { "Alice", "913", "gmail", "Active", "friend" }, lastContacted)),
                 command);
     }
 
@@ -126,30 +131,36 @@ public class AddressBookParserTest {
     public void parseCommand_findm() throws Exception {
         LocalDateTime start = LocalDateTime.parse("20.09.2023 1000", FORMAT);
         LocalDateTime end = LocalDateTime.parse("20.09.2023 1200", FORMAT);
-        FindMeetingCommand command = (FindMeetingCommand) parser
-                .parseCommand(FindMeetingCommand.COMMAND_WORD
-                        + " m/CS2103T a/Zoom s/20.09.2023 1000 e/20.09.2023 1200 n/Alice Bob t/friend");
-        assertEquals(new FindMeetingCommand(
-                prepareMeetingPredicate(new String[] {"CS2103T", "Zoom", "Alice Bob", "friend"}, start, end)),
+        FindMeetingCommand command = (FindMeetingCommand) parser.parseCommand(FindMeetingCommand.COMMAND_WORD
+                + " m/CS2103T a/Zoom s/20.09.2023 1000 e/20.09.2023 1200 n/Alice Bob t/friend");
+        assertEquals(
+                new FindMeetingCommand(
+                        prepareMeetingPredicate(new String[] { "CS2103T", "Zoom", "Alice Bob", "friend" }, start, end)),
                 command);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
+                () -> parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
     public void parseCommand_listc() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
+                () -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
     public void parseCommand_listm() throws Exception {
         assertTrue(parser.parseCommand(ListMeetingCommand.COMMAND_WORD) instanceof ListMeetingCommand);
-        assertTrue(parser.parseCommand(ListMeetingCommand.COMMAND_WORD + " 3") instanceof ListMeetingCommand);
+
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
+                () -> parser.parseCommand(ListMeetingCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -175,8 +186,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_COMMAND_FORMAT + "\n" + HelpCommand.MESSAGE_USAGE, (
-                ) -> parser.parseCommand(""));
+        assertThrows(ParseException.class, MESSAGE_INVALID_COMMAND_FORMAT + "\n" + HelpCommand.MESSAGE_USAGE,
+                () -> parser.parseCommand(""));
     }
 
     @Test
@@ -187,8 +198,8 @@ public class AddressBookParserTest {
     /**
      * Parses {@code userInput} into a {@code GeneralMeetingPredicate}.
      */
-    private GeneralMeetingPredicate prepareMeetingPredicate(String[] userInput,
-                                                            LocalDateTime start, LocalDateTime end) {
+    private GeneralMeetingPredicate prepareMeetingPredicate(String[] userInput, LocalDateTime start,
+            LocalDateTime end) {
         return new GeneralMeetingPredicate(new TitleContainsKeywordsPredicate(List.of(userInput[0].split("\\s+"))),
                 new LocationContainsKeywordsPredicate(List.of(userInput[1].split("\\s+"))),
                 new MeetingTimeContainsPredicate(start, end),
@@ -200,13 +211,11 @@ public class AddressBookParserTest {
      * Parses {@code userInput} into a {@code GeneralPersonPredicate}.
      */
     private GeneralPersonPredicate preparePersonPredicate(String[] userInput, LocalDateTime lastContacted) {
-        return new GeneralPersonPredicate(
-                new NameContainsKeywordsPredicate(List.of(userInput[0].split("\\s+"))),
+        return new GeneralPersonPredicate(new NameContainsKeywordsPredicate(List.of(userInput[0].split("\\s+"))),
                 new PhoneContainsPredicate(List.of(userInput[1].split("\\s+"))),
                 new EmailContainsKeywordsPredicate(List.of(userInput[2].split("\\s+"))),
                 new LastContactTimeContainsPredicate(lastContacted),
                 new StatusContainsKeywordsPredicate(List.of(userInput[3].split("\\s+"))),
-                new PersonTagContainsKeywordsPredicate(List.of(userInput[4].split("\\s+")))
-        );
+                new PersonTagContainsKeywordsPredicate(List.of(userInput[4].split("\\s+"))));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -78,8 +78,8 @@ public class AddressBookParserTest {
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
 
-        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
-                () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, (
+                ) -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -113,8 +113,8 @@ public class AddressBookParserTest {
     public void parseCommand_exit() throws Exception {
         assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
 
-        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
-                () -> parser.parseCommand(ExitCommand.COMMAND_WORD + " 3"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, (
+                ) -> parser.parseCommand(ExitCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -143,24 +143,24 @@ public class AddressBookParserTest {
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
 
-        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
-                () -> parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, (
+                ) -> parser.parseCommand(HelpCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
     public void parseCommand_listc() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
 
-        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
-                () -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, (
+                ) -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
     public void parseCommand_listm() throws Exception {
         assertTrue(parser.parseCommand(ListMeetingCommand.COMMAND_WORD) instanceof ListMeetingCommand);
 
-        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS,
-                () -> parser.parseCommand(ListMeetingCommand.COMMAND_WORD + " 3"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, (
+                ) -> parser.parseCommand(ListMeetingCommand.COMMAND_WORD + " 3"));
     }
 
     @Test
@@ -186,8 +186,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_COMMAND_FORMAT + "\n" + HelpCommand.MESSAGE_USAGE,
-                () -> parser.parseCommand(""));
+        assertThrows(ParseException.class, MESSAGE_INVALID_COMMAND_FORMAT + "\n" + HelpCommand.MESSAGE_USAGE, (
+                ) -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -175,7 +175,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), (
+        assertThrows(ParseException.class, MESSAGE_INVALID_COMMAND_FORMAT + "\n" + HelpCommand.MESSAGE_USAGE, (
                 ) -> parser.parseCommand(""));
     }
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -10,11 +11,11 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.DeleteCommand;
 
 /**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the DeleteCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * As we are only doing white-box testing, our test cases do not cover path
+ * variations outside of the DeleteCommand code. For example, inputs "1" and "1
+ * abc" take the same path through the DeleteCommand, and therefore we test only
+ * one of them. The path variation for those two cases occur inside the
+ * ParserUtil, and therefore should be covered by the ParserUtilTest.
  */
 public class DeleteCommandParserTest {
 
@@ -27,6 +28,10 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        // incorrect index format
+        assertParseFailure(parser, "a", MESSAGE_INVALID_INDEX_FORMAT + "\n" + DeleteCommand.MESSAGE_USAGE);
+
+        // missing index
+        assertParseFailure(parser, "", MESSAGE_MISSING_INDEX + "\n" + DeleteCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteMeetingCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
@@ -10,11 +11,12 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.DeleteMeetingCommand;
 
 /**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteMeetingCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the DeleteMeetingCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * As we are only doing white-box testing, our test cases do not cover path
+ * variations outside of the DeleteMeetingCommand code. For example, inputs "1"
+ * and "1 abc" take the same path through the DeleteMeetingCommand, and
+ * therefore we test only one of them. The path variation for those two cases
+ * occur inside the ParserUtil, and therefore should be covered by the
+ * ParserUtilTest.
  */
 public class DeleteMeetingCommandParserTest {
 
@@ -27,7 +29,10 @@ public class DeleteMeetingCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE));
+        // incorrect index format
+        assertParseFailure(parser, "a", MESSAGE_INVALID_INDEX_FORMAT + "\n" + DeleteMeetingCommand.MESSAGE_USAGE);
+
+        // missing index
+        assertParseFailure(parser, "", MESSAGE_MISSING_INDEX + "\n" + DeleteMeetingCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -86,21 +86,30 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid email
-        assertParseFailure(parser, "1" + INVALID_STATUS_DESC, Status.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid status
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid tag
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC,
+                Name.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid name
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC,
+                Phone.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid phone
+        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC,
+                Email.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid email
+        assertParseFailure(parser, "1" + INVALID_STATUS_DESC,
+                Status.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid status
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid tag
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY,
+                Phone.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code
         // Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
@@ -189,24 +198,28 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + EditCommand.MESSAGE_USAGE);
 
         // invalid followed by valid
         userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + EditCommand.MESSAGE_USAGE);
 
         // multiple valid fields repeated
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_AMY
                 + EMAIL_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL) + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL)
+                + "\n" + EditCommand.MESSAGE_USAGE);
 
         // multiple invalid values
         userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC + INVALID_PHONE_DESC
                 + INVALID_EMAIL_DESC;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL) + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL)
+                + "\n" + EditCommand.MESSAGE_USAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_FIELDS;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
@@ -51,58 +53,58 @@ public class EditCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
-    private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
-
     private EditCommandParser parser = new EditCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        // no index specified but field specific
+        assertParseFailure(parser, NAME_DESC_AMY, MESSAGE_MISSING_INDEX + "\n" + EditCommand.MESSAGE_USAGE);
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED + "\n" + EditCommand.MESSAGE_USAGE);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_MISSING_INDEX + "\n" + EditCommand.MESSAGE_USAGE);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY,
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + EditCommand.MESSAGE_USAGE);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY,
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + EditCommand.MESSAGE_USAGE);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FIELDS + "\n" + EditCommand.MESSAGE_USAGE);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FIELDS + "\n" + EditCommand.MESSAGE_USAGE);
     }
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_STATUS_DESC, Status.MESSAGE_CONSTRAINTS); // invalid status
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid name
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid phone
+        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid email
+        assertParseFailure(parser, "1" + INVALID_STATUS_DESC, Status.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid status
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE); // invalid tag
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
+        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code
+        // Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
-                Name.MESSAGE_CONSTRAINTS);
+                Name.MESSAGE_CONSTRAINTS + "\n" + EditCommand.MESSAGE_USAGE);
     }
 
     @Test
@@ -113,8 +115,8 @@ public class EditCommandParserTest {
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withLastContactedTime(VALID_LASTTIME_AMY)
-                .withStatus(VALID_STATUS_AMY).withRemark(REMARK_DESC_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withStatus(VALID_STATUS_AMY).withRemark(REMARK_DESC_AMY).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+                .build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -187,27 +189,24 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + EditCommand.MESSAGE_USAGE);
 
         // invalid followed by valid
         userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE) + "\n" + EditCommand.MESSAGE_USAGE);
 
         // multiple valid fields repeated
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_AMY
+                + EMAIL_DESC_AMY + TAG_DESC_FRIEND + PHONE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
-        assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL) + "\n" + EditCommand.MESSAGE_USAGE);
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_EMAIL_DESC;
+        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC + INVALID_PHONE_DESC
+                + INVALID_EMAIL_DESC;
 
-        assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL) + "\n" + EditCommand.MESSAGE_USAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditMeetingCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_FIELDS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.END_DESC_MEETING1;
@@ -79,7 +80,7 @@ public class EditMeetingCommandParserTest {
 
         // invalid prefix being parsed as preamble
         assertParseFailure(parser, "1 i/ nonono",
-                MESSAGE_INVALID_INDEX_FORMAT + "\n" + EditMeetingCommand.MESSAGE_USAGE);
+                MESSAGE_INVALID_FIELDS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditMeetingCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.END_DESC_MEETING1;
 import static seedu.address.logic.commands.CommandTestUtil.END_DESC_MEETING2;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_DESC;
@@ -46,63 +47,73 @@ public class EditMeetingCommandParserTest {
 
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
-    private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditMeetingCommand.MESSAGE_USAGE);
-
     private EditMeetingCommandParser parser = new EditMeetingCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_TITLE_MEETING1, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, TITLE_DESC_MEETING1,
+                MESSAGE_MISSING_INDEX + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // no field specified
-        assertParseFailure(parser, "1", EditMeetingCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1",
+                EditMeetingCommand.MESSAGE_NOT_EDITED + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", MESSAGE_MISSING_INDEX + "\n" + EditMeetingCommand.MESSAGE_USAGE);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + TITLE_DESC_MEETING1, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + TITLE_DESC_MEETING1,
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // zero index
-        assertParseFailure(parser, "0" + TITLE_DESC_MEETING1, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + TITLE_DESC_MEETING1,
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "general kenobi :)", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "general kenobi :)",
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ nonono", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ nonono",
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + EditMeetingCommand.MESSAGE_USAGE);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid title
-        assertParseFailure(parser, "1" + INVALID_TITLE_DESC, Title.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_TITLE_DESC,
+                Title.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
         // invalid location
-        assertParseFailure(parser, "1" + INVALID_LOCATION_DESC, Location.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_LOCATION_DESC,
+                Location.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
         // invalid meeting time
         assertParseFailure(parser, "1" + INVALID_START_DESC + INVALID_END_DESC,
-                MeetingTime.MESSAGE_CONSTRAINTS);
+                MeetingTime.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
         // invalid tag
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_TAG_DESC,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // invalid title followed by valid location
         assertParseFailure(parser, "1" + INVALID_TITLE_DESC + LOCATION_DESC_MEETING1,
-                Title.MESSAGE_CONSTRAINTS);
+                Title.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Meeting} being edited,
+        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code
+        // Meeting} being edited,
         // parsing it together with a valid tag results in an error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_WORK + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_WORK, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_WORK, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_WORK + TAG_EMPTY,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_WORK,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_WORK,
+                Tag.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_TITLE_DESC + INVALID_LOCATION_DESC + VALID_START_MEETING1,
-                Title.MESSAGE_CONSTRAINTS);
+                Title.MESSAGE_CONSTRAINTS + "\n" + EditMeetingCommand.MESSAGE_USAGE);
     }
 
     @Test
@@ -157,25 +168,29 @@ public class EditMeetingCommandParserTest {
         Index targetIndex = INDEX_FIRST_MEETING;
         String userInput = targetIndex.getOneBased() + INVALID_LOCATION_DESC + LOCATION_DESC_MEETING1;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION) + "\n"
+                + EditMeetingCommand.MESSAGE_USAGE);
 
         // invalid followed by valid
         userInput = targetIndex.getOneBased() + LOCATION_DESC_MEETING1 + INVALID_LOCATION_DESC;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION));
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_LOCATION) + "\n"
+                + EditMeetingCommand.MESSAGE_USAGE);
 
         // multiple valid fields repeated
         userInput = targetIndex.getOneBased() + TITLE_DESC_MEETING1 + TITLE_DESC_MEETING2 + LOCATION_DESC_MEETING1
-            + END_DESC_MEETING1 + END_DESC_MEETING2;
+                + END_DESC_MEETING1 + END_DESC_MEETING2;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE, PREFIX_END));
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE, PREFIX_END)
+                + "\n" + EditMeetingCommand.MESSAGE_USAGE);
 
         // multiple invalid values
         userInput = targetIndex.getOneBased() + INVALID_LOCATION_DESC + INVALID_TITLE_DESC + INVALID_LOCATION_DESC
                 + INVALID_TITLE_DESC;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE, PREFIX_LOCATION));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_TITLE, PREFIX_LOCATION) + "\n"
+                        + EditMeetingCommand.MESSAGE_USAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -27,7 +27,7 @@ public class FindCommandParserTest {
     @Test
     public void parse_nonEmptyPreambleArg_throwsParseException() {
         assertParseFailure(parser, " bobby n/Alice",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_COMMAND_FORMAT + "\n" + FindCommand.MESSAGE_USAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindMeetingCommandParserTest.java
@@ -27,7 +27,7 @@ public class FindMeetingCommandParserTest {
     @Test
     public void parse_nonEmptyPreambleArg_throwsParseException() {
         assertParseFailure(parser, " dfvuv m/CS2103T",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindMeetingCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_COMMAND_FORMAT + "\n" + FindMeetingCommand.MESSAGE_USAGE);
     }
 
     @Test
@@ -81,7 +81,7 @@ public class FindMeetingCommandParserTest {
     @Test
     public void parse_inValidArgsTime_throwsParseException() {
         assertParseFailure(parser, " e/20.09.2023 1000 s/20.09.2023 1200",
-                String.format(MeetingTime.MESSAGE_CONSTRAINTS));
+                MeetingTime.MESSAGE_CONSTRAINTS + "\n" + FindMeetingCommand.MESSAGE_USAGE);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/MarkMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkMeetingCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
@@ -10,11 +11,11 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.MarkMeetingCommand;
 
 /**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the MarkMeetingCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the MarkMeetingCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * As we are only doing white-box testing, our test cases do not cover path
+ * variations outside of the MarkMeetingCommand code. For example, inputs "1"
+ * and "1 abc" take the same path through the MarkMeetingCommand, and therefore
+ * we test only one of them. The path variation for those two cases occur inside
+ * the ParserUtil, and therefore should be covered by the ParserUtilTest.
  */
 public class MarkMeetingCommandParserTest {
 
@@ -27,7 +28,12 @@ public class MarkMeetingCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
+        // incorrect index format
         assertParseFailure(parser, "a",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkMeetingCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + MarkMeetingCommand.MESSAGE_USAGE);
+
+        // missing index
+        assertParseFailure(parser, "",
+                MESSAGE_MISSING_INDEX + "\n" + MarkMeetingCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -58,8 +58,8 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT,
-                () -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
+                ) -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -2,7 +2,10 @@ package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_FIELDS;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_TOO_MANY_INDEXES;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
@@ -39,13 +42,20 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
+                ) -> ParserUtil.parseIndex("10 a"));
     }
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, (
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
                 ) -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+    }
+
+    @Test
+    public void parseIndex_emptyInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_MISSING_INDEX, (       
+                ) -> ParserUtil.parseIndex(""));
     }
 
     @Test
@@ -59,27 +69,51 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndexes_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseIndexes("10 10 w"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
+                ) -> ParserUtil.parseIndexes("10 10 w", 3));
     }
 
     @Test
     public void parseIndexes_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, (
-                ) -> ParserUtil.parseIndexes("1 0 4"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
+                ) -> ParserUtil.parseIndexes("1 0 4", 3));
+    }
+
+    @Test
+    public void parseIndexes_tooFewArgs_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_MISSING_INDEX, (
+                ) -> ParserUtil.parseIndexes("10 10", 3));
+    }
+
+    @Test
+    public void parseIndexes_tooManyNumericArgs_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_TOO_MANY_INDEXES, (
+                ) -> ParserUtil.parseIndexes("10 10", 1));
+    }
+
+    @Test
+    public void parseIndexes_tooManyNonNumericArgs_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, (
+            ) -> ParserUtil.parseIndexes("10 w", 1));
+    }
+
+    @Test
+    public void parseIndexes_nonPositiveExpectedIndexes_throwsAssertionError() {
+        assertThrows(AssertionError.class, () -> ParserUtil.parseIndexes("", 0));
     }
 
     @Test
     public void parseIndexes_validInput_success() throws Exception {
         // Single index
         List<Index> singleIndexList = List.of(INDEX_FIRST_PERSON);
-        assertEquals(singleIndexList, ParserUtil.parseIndexes("1"));
+        assertEquals(singleIndexList, ParserUtil.parseIndexes("1", 1));
 
         // Multiple indexes
         List<Index> multipleIndexList = List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON, INDEX_THIRD_PERSON);
-        assertEquals(multipleIndexList, ParserUtil.parseIndexes("1 2 3"));
+        assertEquals(multipleIndexList, ParserUtil.parseIndexes("1 2 3", 3));
 
         // Different whitespaces
-        assertEquals(multipleIndexList, ParserUtil.parseIndexes(" 1  2      3   "));
+        assertEquals(multipleIndexList, ParserUtil.parseIndexes(" 1  2      3   ", 3));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_FIELDS;
@@ -41,21 +42,29 @@ public class ParserUtilTest {
     private static final String WHITESPACE = " \t\r\n";
 
     @Test
+    public void verifyNoArgs_argsPresent_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, () -> ParserUtil.verifyNoArgs("10 a"));
+    }
+
+    @Test
+    public void verifyNoArgs_noArgs_success() {
+        assertDoesNotThrow(() -> ParserUtil.verifyNoArgs(""));
+    }
+
+    @Test
     public void parseIndex_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
-                ) -> ParserUtil.parseIndex("10 a"));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, () -> ParserUtil.parseIndex("10 a"));
     }
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
-                ) -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT,
+                () -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 
     @Test
     public void parseIndex_emptyInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_MISSING_INDEX, (       
-                ) -> ParserUtil.parseIndex(""));
+        assertThrows(ParseException.class, MESSAGE_MISSING_INDEX, () -> ParserUtil.parseIndex(""));
     }
 
     @Test
@@ -69,32 +78,27 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndexes_invalidInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
-                ) -> ParserUtil.parseIndexes("10 10 w", 3));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, () -> ParserUtil.parseIndexes("10 10 w", 3));
     }
 
     @Test
     public void parseIndexes_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, (
-                ) -> ParserUtil.parseIndexes("1 0 4", 3));
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX_FORMAT, () -> ParserUtil.parseIndexes("1 0 4", 3));
     }
 
     @Test
     public void parseIndexes_tooFewArgs_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_MISSING_INDEX, (
-                ) -> ParserUtil.parseIndexes("10 10", 3));
+        assertThrows(ParseException.class, MESSAGE_MISSING_INDEX, () -> ParserUtil.parseIndexes("10 10", 3));
     }
 
     @Test
     public void parseIndexes_tooManyNumericArgs_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_TOO_MANY_INDEXES, (
-                ) -> ParserUtil.parseIndexes("10 10", 1));
+        assertThrows(ParseException.class, MESSAGE_TOO_MANY_INDEXES, () -> ParserUtil.parseIndexes("10 10", 1));
     }
 
     @Test
     public void parseIndexes_tooManyNonNumericArgs_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, (
-            ) -> ParserUtil.parseIndexes("10 w", 1));
+        assertThrows(ParseException.class, MESSAGE_INVALID_FIELDS, () -> ParserUtil.parseIndexes("10 w", 1));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/RemoveMeetingContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RemoveMeetingContactCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
+import static seedu.address.logic.Messages.MESSAGE_TOO_MANY_INDEXES;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
@@ -12,14 +14,11 @@ import seedu.address.logic.commands.RemoveMeetingContactCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path
- * variations
- * outside of the RemoveMeetingContactCommand code. For example, inputs "1" and
- * "1 abc" take
- * the
- * same path through the RemoveMeetingContactCommand, and therefore we test only
- * one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * variations outside of the RemoveMeetingContactCommand code. For example,
+ * inputs "1" and "1 abc" take the same path through the
+ * RemoveMeetingContactCommand, and therefore we test only one of them. The path
+ * variation for those two cases occur inside the ParserUtil, and therefore
+ * should be covered by the ParserUtilTest.
  */
 public class RemoveMeetingContactCommandParserTest {
 
@@ -34,14 +33,13 @@ public class RemoveMeetingContactCommandParserTest {
     public void parse_invalidArgs_throwsParseException() {
         // invalid args
         assertParseFailure(parser, "a 1",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveMeetingContactCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + RemoveMeetingContactCommand.MESSAGE_USAGE);
 
         // too many args
         assertParseFailure(parser, "1 1 2",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveMeetingContactCommand.MESSAGE_USAGE));
+                MESSAGE_TOO_MANY_INDEXES + "\n" + RemoveMeetingContactCommand.MESSAGE_USAGE);
 
         // too few args
-        assertParseFailure(parser, "2",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemoveMeetingContactCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "2", MESSAGE_MISSING_INDEX + "\n" + RemoveMeetingContactCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ViewContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewContactCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -27,7 +28,12 @@ public class ViewContactCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ViewContactCommand.MESSAGE_USAGE));
+        // incorrect index format
+        assertParseFailure(parser, "a",
+                MESSAGE_INVALID_INDEX_FORMAT + "\n" + ViewContactCommand.MESSAGE_USAGE);
+
+        // missing index
+        assertParseFailure(parser, "",
+                MESSAGE_MISSING_INDEX + "\n" + ViewContactCommand.MESSAGE_USAGE);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ViewMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewMeetingCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_INDEX_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_MISSING_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MEETING;
@@ -10,11 +11,11 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.ViewMeetingCommand;
 
 /**
- * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the ViewMeetingCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the ViewMeetingCommand, and therefore we test only one of them.
- * The path variation for those two cases occur inside the ParserUtil, and
- * therefore should be covered by the ParserUtilTest.
+ * As we are only doing white-box testing, our test cases do not cover path
+ * variations outside of the ViewMeetingCommand code. For example, inputs "1"
+ * and "1 abc" take the same path through the ViewMeetingCommand, and therefore
+ * we test only one of them. The path variation for those two cases occur inside
+ * the ParserUtil, and therefore should be covered by the ParserUtilTest.
  */
 public class ViewMeetingCommandParserTest {
 
@@ -27,7 +28,10 @@ public class ViewMeetingCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                ViewMeetingCommand.MESSAGE_USAGE));
+        // incorrect index format
+        assertParseFailure(parser, "a", MESSAGE_INVALID_INDEX_FORMAT + "\n" + ViewMeetingCommand.MESSAGE_USAGE);
+
+        // missing index
+        assertParseFailure(parser, "", MESSAGE_MISSING_INDEX + "\n" + ViewMeetingCommand.MESSAGE_USAGE);
     }
 }


### PR DESCRIPTION
- `ParseException` also prints error message of its cause - increases specificity of error message displayed
- `parseIndexes` has a new `int expectedIndexes` argument to check for number of indexes given
- All commands that use indexes now use `parseIndexes` for better error detection and also have a `EXPECTED_INDEXES` static var
- `ParserUtil.verifyNoArgs()` method for commands `help`, `exit`, `clear`, `listc`, `listm` to check that no arguments are provided 

fixes #151, fixes #145, fixes #142, fixes #134 